### PR TITLE
only build this module on windows

### DIFF
--- a/windows.go
+++ b/windows.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package config
 
 import (


### PR DESCRIPTION
was getting duplicate symbol errors on OSX and linux. Isolate module to windows-only. The +build syntax should allow this; certainly it no longer attempts to build windows.go on linux & OSX.
